### PR TITLE
refactor: clean up SessionPhase after code review

### DIFF
--- a/Sources/DHKit/EncounterSession.swift
+++ b/Sources/DHKit/EncounterSession.swift
@@ -28,9 +28,16 @@ import Observation
 // MARK: - SessionPhase
 
 /// The lifecycle phase of a live encounter session.
-public enum SessionPhase: String, Codable, Sendable {
+public enum SessionPhase: String, Sendable {
   case running
   case paused
+}
+
+extension SessionPhase: Codable {
+  public init(from decoder: any Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(String.self)
+    self = SessionPhase(rawValue: raw) ?? .running
+  }
 }
 
 // MARK: - EncounterSession
@@ -108,8 +115,6 @@ public final class EncounterSession: Identifiable, Hashable {
   /// Running total of spotlight grants in this encounter.
   public var spotlightCount: Int
 
-  // MARK: Lifecycle
-
   /// The current lifecycle phase of this session.
   public private(set) var phase: SessionPhase
 
@@ -158,11 +163,13 @@ public final class EncounterSession: Identifiable, Hashable {
 
   /// Pause this session. The session persists and can be resumed later.
   public func pause() {
+    guard phase != .paused else { return }
     phase = .paused
   }
 
   /// Resume a paused session.
   public func resume() {
+    guard phase != .running else { return }
     phase = .running
   }
 
@@ -513,9 +520,7 @@ extension EncounterSession: @MainActor Codable {
     let spotlightedSlotID = try c.decodeIfPresent(UUID.self, forKey: .spotlightedSlotID)
     let spotlightCount = try c.decode(Int.self, forKey: .spotlightCount)
     let gmNotes = try c.decode(String.self, forKey: .gmNotes)
-    let phase =
-      (try c.decodeIfPresent(String.self, forKey: .phase))
-      .flatMap(SessionPhase.init(rawValue:)) ?? .running
+    let phase = try c.decodeIfPresent(SessionPhase.self, forKey: .phase) ?? .running
     let definitionID = try c.decodeIfPresent(UUID.self, forKey: .definitionID)
     let definitionSnapshotDate = try c.decodeIfPresent(Date.self, forKey: .definitionSnapshotDate)
     self.init(

--- a/Tests/DHKitTests/EncounterSessionTests.swift
+++ b/Tests/DHKitTests/EncounterSessionTests.swift
@@ -663,7 +663,7 @@ import Testing
       {"id":"\(UUID().uuidString)","name":"Legacy","adversarySlots":[],"playerSlots":[],\
       "environmentSlots":[],"fearPool":0,"hopePool":0,"spotlightCount":0,"gmNotes":""}
       """
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let decoded = try JSONDecoder().decode(EncounterSession.self, from: data)
     #expect(decoded.phase == .running)
   }
@@ -676,7 +676,7 @@ import Testing
       "environmentSlots":[],"fearPool":0,"hopePool":0,"spotlightCount":0,\
       "gmNotes":"","phase":"completed"}
       """
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let decoded = try JSONDecoder().decode(EncounterSession.self, from: data)
     #expect(decoded.phase == .running)
   }


### PR DESCRIPTION
## Summary

- **`SessionPhase.Codable`**: moved the forward-compatibility fallback (unknown raw value → `.running`) into a custom `init(from:)` on `SessionPhase` itself, so `EncounterSession`'s decoder can use `decodeIfPresent(SessionPhase.self, …)` instead of a stringly-typed `String → rawValue` detour
- **`pause()` / `resume()`**: guard on current value before writing to avoid spurious `@Observable` notifications when the phase is already in the target state (consistent with other mutating methods in the file)
- **Duplicate MARK removed**: `// MARK: Lifecycle` (no-dash property marker) was redundant alongside `// MARK: - Lifecycle` for the methods section
- **Force-unwrap in tests**: replaced `json.data(using: .utf8)!` with `try #require(…)` in the two Codable edge-case tests per project convention

## Test plan

- [x] `swift test --filter DHKitTests` passes (101 tests, 14 suites)
- [x] `SessionPhaseTests` — all phase transition, idempotency, and Codable round-trip cases green
- [x] `missingPhaseKeyDecodesAsRunning` and `unknownFuturePhaseValueDecodesAsRunning` still green with the new `SessionPhase.init(from:)` implementation